### PR TITLE
Misc bugfixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pbiAssure
 Type: Package
 Title: This package creates quality assurance reports for Power BI files.
-Version: 0.0.0.9013
+Version: 0.0.0.9014
 Author: Adam Robinson
 Maintainer: Adam Robinson <adamrobinson361@gmail.com>
 Description: This reads and transforms the underlying json file from a Power BI

--- a/R/extract.R
+++ b/R/extract.R
@@ -297,7 +297,7 @@ create_sections_summary <- function(report){
   lapply(report$sections, create_section_summary) %>%
     dplyr::bind_rows() %>%
     dplyr::arrange(slide_number) %>%
-    select(-slide_number)
+    dplyr::select(-slide_number)
 
 }
 
@@ -371,7 +371,7 @@ create_visuals_summary <- function(report){
     dplyr::transmute(slide_number, slide_name, visual_id, visual_type, visual_title, visual_value, visual_filters) %>%
     dplyr::filter(!(visual_type %in% c("image", "slicer", "basicShape", "actionButton"))) %>%
     dplyr::arrange(slide_number) %>%
-    select(-slide_number)
+    dplyr::select(-slide_number)
 
 }
 

--- a/R/extract.R
+++ b/R/extract.R
@@ -316,7 +316,7 @@ extract_single_visual <- function(single_visual){
 
   if (!is.null(single_visual$config)) {
 
-    config_json <- RJSONIO::fromJSON(gsub("\32", "", gsub('\32\32"', '', single_visual$config)))
+    config_json <- RJSONIO::fromJSON(gsub("\32", "", single_visual$config))
 
     tibble::tibble(
       visual_id = config_json$name,
@@ -388,7 +388,7 @@ create_visuals_summary <- function(report){
 #' }
 extract_textbox <- function(single_visual){
 
-  config_json <- RJSONIO::fromJSON(gsub("\32", "", gsub('\32\32"', '', single_visual$config)))
+  config_json <- RJSONIO::fromJSON(gsub("\32", "", single_visual$config))
 
   if (length(config_json[["singleVisual"]][["visualType"]]) > 0){
 
@@ -421,7 +421,7 @@ extract_value <- function(single_visual){
 
   if (is.null(extract_textbox(single_visual))){
 
-    config_json <- RJSONIO::fromJSON(gsub("\32", "", gsub('\32\32"', '', single_visual$config)))
+    config_json <- RJSONIO::fromJSON(gsub("\32", "", single_visual$config))
 
     projections <- config_json$singleVisual$projections
 

--- a/R/extract.R
+++ b/R/extract.R
@@ -311,15 +311,19 @@ create_sections_summary <- function(report){
 #' }
 extract_single_visual <- function(single_visual){
 
-  config_json <- RJSONIO::fromJSON(single_visual$config)
+  if (!is.null(single_visual$config)) {
 
-  tibble::tibble(
-    visual_id = config_json$name,
-    visual_type = config_json$singleVisual$`visualType`,
-    visual_title = if_null_na(config_json$singleVisual$vcObjects$title[[1]]$properties$text$expr$Literal["Value"]),
-    visual_value = if_null_na(extract_value(single_visual)),
-    visual_filters = extract_filters(single_visual)
+    config_json <- RJSONIO::fromJSON(gsub("\32", "", gsub('\32\32"', '', single_visual$config)))
+
+    tibble::tibble(
+      visual_id = config_json$name,
+      visual_type = config_json$singleVisual$`visualType`,
+      visual_title = if_null_na(config_json$singleVisual$vcObjects$title[[1]]$properties$text$expr$Literal["Value"]),
+      visual_value = if_null_na(extract_value(single_visual)),
+      visual_filters = extract_filters(single_visual)
     )
+
+  }
 
 }
 
@@ -375,7 +379,7 @@ create_visuals_summary <- function(report){
 #' }
 extract_textbox <- function(single_visual){
 
-  config_json <- RJSONIO::fromJSON(single_visual$config)
+  config_json <- RJSONIO::fromJSON(gsub("\32", "", gsub('\32\32"', '', single_visual$config)))
 
   if (length(config_json[["singleVisual"]][["visualType"]]) > 0){
 
@@ -404,7 +408,7 @@ extract_value <- function(single_visual){
 
   if (is.null(extract_textbox(single_visual))){
 
-    config_json <- RJSONIO::fromJSON(single_visual$config)
+    config_json <- RJSONIO::fromJSON(gsub("\32", "", gsub('\32\32"', '', single_visual$config)))
 
     projections <- config_json$singleVisual$projections
 

--- a/R/read.R
+++ b/R/read.R
@@ -11,11 +11,13 @@
 
 read_layout <- function(file){
 
-  file1 <- readLines(file, warn = FALSE, skipNul = TRUE)
+  file1 <- readLines(file, warn = FALSE, skipNul = TRUE, encoding = "windows-1252")
 
-  file1 <- iconv(file1, "windows-1252", "UTF-8")
+  file1 <- stringi::stri_enc_toascii(file1)
 
-  RJSONIO::fromJSON(file1, digits = 15)
+  file1 <- gsub("/", "", file1)
+
+  report <- RJSONIO::fromJSON(file1, digits = 15)
 
 }
 

--- a/R/read.R
+++ b/R/read.R
@@ -11,13 +11,11 @@
 
 read_layout <- function(file){
 
-  file1 <- readLines(file, warn = FALSE, skipNul = TRUE, encoding = "windows-1252")
+  file1 <- readLines(file, warn = FALSE, skipNul = TRUE)
 
-  file1 <- stringi::stri_enc_toascii(file1)
+  file1 <- iconv(file1, "windows-1252", "UTF-8")
 
-  file1 <- gsub("/", "", file1)
-
-  report <- RJSONIO::fromJSON(file1, digits = 15)
+  RJSONIO::fromJSON(file1, digits = 15)
 
 }
 
@@ -45,4 +43,3 @@ read_pbi <- function(file){
   read_layout(file.path(unzip_folder_path, "report/Layout"))
 
 }
-

--- a/R/report.R
+++ b/R/report.R
@@ -188,8 +188,12 @@ create_qa_report <- function(report, output_file = "pbi_qa_report.xlsx"){
     ) %>%
     # Manual quick fix for removing escape character causing problems
     dplyr::mutate(
+      visual_value = gsub("\30", "", visual_value),
       visual_value = gsub("\31", "", visual_value),
-      visual_value = gsub("\30", "", visual_value)
+      visual_value = gsub("\32", "", visual_value),
+      visual_value = gsub("\33", "", visual_value),
+      visual_value = gsub("\34", "", visual_value),
+      visual_value = gsub("\35", "", visual_value)
     )
 
   validation_cells_visuals_summary_final <- which(grepl("correct|updates|changes|clear|differences|actioned", names(visuals_summary)))


### PR DESCRIPTION
Misc changes to help read and write Power BI files. What this does:

- Reorders the output tables based on ordinal number. Some Power BI's were coming out unordered.
- Replaces a number of escaped characters with blank when writing output to ensure not corrupted output